### PR TITLE
Complexity Algorithm

### DIFF
--- a/AlttpRandomizer/IO/RandomizerLog.cs
+++ b/AlttpRandomizer/IO/RandomizerLog.cs
@@ -13,6 +13,7 @@ namespace AlttpRandomizer.IO
         private readonly List<Location> generatedItems;
         private readonly List<Location> orderedItems;
         private readonly List<Location> specialLocations;
+        private readonly List<List<Location>> reachableKeyItems;
         private readonly string seed;
 
         public RandomizerLog(string seed)
@@ -20,6 +21,7 @@ namespace AlttpRandomizer.IO
             generatedItems = new List<Location>();
             orderedItems = new List<Location>();
             specialLocations = new List<Location>();
+            reachableKeyItems = new List<List<Location>>();
             this.seed = seed;
         }
 
@@ -63,6 +65,11 @@ namespace AlttpRandomizer.IO
         {
             specialLocations.AddRange(locations);
         }
+ 
+        public void AddReachableKeyItems(List<Location> Location)
+        {
+            reachableKeyItems.Add(Location);
+        }
 
         public void WriteLog(string filename)
         {
@@ -80,7 +87,23 @@ namespace AlttpRandomizer.IO
             writer.AppendLine("---------------------------------");
             writer.AppendLine(string.Format("Version: {0}", RandomizerVersion.CurrentDisplay));
             writer.AppendLine(string.Format("Creation Date: {0}", DateTime.Now));
+            writer.AppendLine(string.Format("Complexity: {0}", reachableKeyItems.Count));
             writer.AppendLine(string.Format("Seed: {0}", seed));
+            for (int i = 0; i < reachableKeyItems.Count; i++)
+            {
+                writer.AppendLine();
+                if (i == 0)
+                    writer.AppendLine("Step 1 - Items reachable from start:");
+                else
+                    writer.AppendLine(string.Format("Step {0} - Items reachable after collecting all items from Step {1}:", i + 1, i));
+                
+                foreach (var Location in reachableKeyItems[i].OrderBy(x => x.Name))
+                {
+                    writer.AppendLine(string.Format("  {0}{1}", Location.Name.PadRight(90, '.'), GetItemName(Location.Item)));
+                }
+            }
+            writer.AppendLine();
+            writer.AppendLine();
             writer.AppendLine();
             writer.AppendLine("Generated Item Order");
             writer.AppendLine("--------------------");

--- a/AlttpRandomizer/MainForm.Designer.cs
+++ b/AlttpRandomizer/MainForm.Designer.cs
@@ -49,6 +49,7 @@
             this.create = new System.Windows.Forms.Button();
             this.randomSpoiler = new System.Windows.Forms.Button();
             this.report = new System.Windows.Forms.Button();
+            this.showComplexity = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bulkCreateCount)).BeginInit();
@@ -154,6 +155,7 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.showComplexity);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Controls.Add(this.heartBeepSpeed);
             this.groupBox1.Controls.Add(this.checkForUpdates);
@@ -323,6 +325,18 @@
             this.report.UseVisualStyleBackColor = true;
             this.report.Click += new System.EventHandler(this.report_Click);
             // 
+            // showComplexity
+            // 
+            this.showComplexity.AutoSize = true;
+            this.showComplexity.Checked = true;
+            this.showComplexity.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.showComplexity.Location = new System.Drawing.Point(6, 96);
+            this.showComplexity.Name = "showComplexity";
+            this.showComplexity.Size = new System.Drawing.Size(106, 17);
+            this.showComplexity.TabIndex = 39;
+            this.showComplexity.Text = "Show Complexity";
+            this.showComplexity.UseVisualStyleBackColor = true;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -371,6 +385,7 @@
         private System.Windows.Forms.ComboBox heartBeepSpeed;
         private System.Windows.Forms.Button bulkCreate;
         private System.Windows.Forms.NumericUpDown bulkCreateCount;
+        private System.Windows.Forms.CheckBox showComplexity;
     }
 }
 

--- a/AlttpRandomizer/MainForm.cs
+++ b/AlttpRandomizer/MainForm.cs
@@ -27,6 +27,7 @@ namespace AlttpRandomizer
         {
             // this fixes an issue with running on wine
             Settings.Default.SramTrace = Settings.Default.SramTrace;
+            Settings.Default.ShowComplexity = Settings.Default.ShowComplexity;
             Settings.Default.OutputFile = Settings.Default.OutputFile;
             Settings.Default.RandomizerDifficulty = Settings.Default.RandomizerDifficulty;
             Settings.Default.CreateSpoilerLog = Settings.Default.CreateSpoilerLog;
@@ -71,13 +72,20 @@ namespace AlttpRandomizer
 
                     seed.Text = string.Format(romLocations.SeedFileString, parsedSeed);
 
-                    CreateRom(romLocations, log, difficulty, parsedSeed);
+                    int complexity = CreateRom(romLocations, log, difficulty, parsedSeed);
 
                     var outputString = new StringBuilder();
 
                     outputString.AppendFormat("Done!{0}{0}{0}Seed: ", Environment.NewLine);
                     outputString.AppendFormat(romLocations.SeedFileString, parsedSeed);
-                    outputString.AppendFormat(" ({0} Difficulty){1}{1}", romLocations.DifficultyName, Environment.NewLine);
+                    if (showComplexity.Checked)
+                    {
+                        outputString.AppendFormat(" ({0} Difficulty - Complexity {2}){1}{1}", romLocations.DifficultyName, Environment.NewLine, complexity);
+                    }
+                    else
+                    {
+                        outputString.AppendFormat(" ({0} Difficulty){1}{1}", romLocations.DifficultyName, Environment.NewLine);
+                    }
 
                     WriteOutput(outputString.ToString());
                 }
@@ -94,6 +102,7 @@ namespace AlttpRandomizer
         private void SaveRandomizerSettings()
         {
             Settings.Default.SramTrace = sramTrace.Checked;
+            Settings.Default.ShowComplexity = showComplexity.Checked;
             Settings.Default.CreateSpoilerLog = createSpoilerLog.Checked;
             Settings.Default.RandomizerDifficulty = randomizerDifficulty.SelectedItem.ToString();
             Settings.Default.HeartBeepSpeed = heartBeepSpeed.SelectedItem.ToString();
@@ -102,18 +111,21 @@ namespace AlttpRandomizer
             Settings.Default.Save();
         }
 
-        private void CreateRom(IRomLocations romLocations, RandomizerLog log, RandomizerDifficulty difficulty, int parsedSeed)
+        private int CreateRom(IRomLocations romLocations, RandomizerLog log, RandomizerDifficulty difficulty, int parsedSeed)
         {
             var randomizer = new Randomizer(parsedSeed, romLocations, log);
             var options = new RandomizerOptions
                             {
                                 Filename = filename.Text,
                                 SramTrace = sramTrace.Checked,
+                                ShowComplexity = showComplexity.Checked,
                                 Difficulty = difficulty,
                                 HeartBeepSpeed = GetHeartBeepSpeed(),
                             };
 
             randomizer.CreateRom(options);
+
+            return randomizer.GetComplexity();
         }
 
         private HeartBeepSpeed GetHeartBeepSpeed()
@@ -267,6 +279,7 @@ namespace AlttpRandomizer
             filename.Text = Settings.Default.OutputFile;
             createSpoilerLog.Checked = Settings.Default.CreateSpoilerLog;
             sramTrace.Checked = Settings.Default.SramTrace;
+            showComplexity.Checked = Settings.Default.ShowComplexity;
             Text = string.Format("A Link to the Past Randomizer v{0}", RandomizerVersion.CurrentDisplay);
             randomizerDifficulty.SelectedItem = Settings.Default.RandomizerDifficulty;
             heartBeepSpeed.SelectedItem = Settings.Default.HeartBeepSpeed;

--- a/AlttpRandomizer/Properties/Settings.Designer.cs
+++ b/AlttpRandomizer/Properties/Settings.Designer.cs
@@ -74,6 +74,18 @@ namespace AlttpRandomizer.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowComplexity {
+            get {
+                return ((bool)(this["ShowComplexity"]));
+            }
+            set {
+                this["ShowComplexity"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool CheckForUpdates {
             get {
                 return ((bool)(this["CheckForUpdates"]));

--- a/AlttpRandomizer/Rom/Item.cs
+++ b/AlttpRandomizer/Rom/Item.cs
@@ -474,6 +474,24 @@ namespace AlttpRandomizer.Rom
                 case InventoryItemType.RedMail:
                     retVal.Append("purple hat");
                     break;
+                case InventoryItemType.ThreeBombs:
+                case InventoryItemType.TenBombs:
+                case InventoryItemType.Bomb:
+                case InventoryItemType.FiftyBombCap:
+                    retVal.Append("fireworks");
+                    break;
+                case InventoryItemType.Arrow:
+                case InventoryItemType.TenArrows:
+                case InventoryItemType.SeventyArrowCap:
+                    retVal.Append("sewing kit");
+                    break;
+               case InventoryItemType.PieceOfHeart:
+               case InventoryItemType.HeartContainerNoAnimation:
+               case InventoryItemType.HeartContainerNoRefill:
+               case InventoryItemType.HeartContainer:
+               case InventoryItemType.Heart:
+                    retVal.Append("love");
+                    break;
                 default:
                     retVal.Append("life lesson");
                     break;
@@ -520,5 +538,26 @@ namespace AlttpRandomizer.Rom
             return inputBytes;
         }
 
+        public static bool IsBottle(InventoryItemType item)
+        {
+            switch (item)
+            {
+                case InventoryItemType.Bottle:
+                case InventoryItemType.BottleWithRedPotion:
+                case InventoryItemType.BottleWithGreenPotion:
+                case InventoryItemType.BottleWithBluePotion:
+                case InventoryItemType.BottleWithBee:
+                case InventoryItemType.BottleWithFairy:
+                case InventoryItemType.BottleWithGoldBee:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsKeyItem(InventoryItemType item)
+        {
+            return GetCheckLocation(item)[0] != GetCheckLocation(InventoryItemType.Nothing)[0] || IsBottle(item);
+        }
     }
 }


### PR DESCRIPTION
Hi everyone,
first of all let me thank you all for the great work and the fantastic item randomizer for alttp. I have quite enjoyed playing it for the last couple of weeks.
There was only one minor issue I had when playing it for the first couple times and that was that for my taste too much items where reachable right from the start. I thought about this problem a little and came up with an easy solution that I want to share with you and hope I can give something back in this way...

The idea is quite simple: Without changing the algorithm of the randomizer calculate somehow an indicator for "complexity" of the seed. So the player can choose if the seed is chalanging/easy enough without being spoiled to much.
The algorithm for the calculation is very simple (just check one of the spoiler logs and you will immediatly get the idea).

I hope you have some use of my little contribution... 
Thanks and keep up with the great work!