### PR TITLE
Bug Fixes

### DIFF
--- a/AlttpRandomizer/IO/RandomizerLog.cs
+++ b/AlttpRandomizer/IO/RandomizerLog.cs
@@ -93,6 +93,7 @@ namespace AlttpRandomizer.IO
             AppendGeneratedItemOrder(writer);
             AppendInventoryItems(writer);
             AppendSpecialItems(writer);
+            AppendMagicUpgrade(writer);
 
             return writer.ToString();
         }
@@ -104,6 +105,15 @@ namespace AlttpRandomizer.IO
             AppendLightWorldDungeonItems(writer);
             AppendDarkWorldDungeonItems(writer);
             writer.AppendLine();
+            writer.AppendLine();
+        }
+
+        private void AppendMagicUpgrade(StringBuilder writer)
+        {
+            foreach (var Location in generatedItems.Where(x => x.Item.HexValue != 0xFF && GetItemName(x.Item).StartsWith("1/")))
+            {
+                writer.AppendLine(string.Format("{0}{1}", "Magic Upgrade".PadRight(90, '.'), GetItemName(Location.Item)));
+            }
             writer.AppendLine();
         }
 

--- a/AlttpRandomizer/Random/Randomizer.cs
+++ b/AlttpRandomizer/Random/Randomizer.cs
@@ -75,7 +75,8 @@ namespace AlttpRandomizer.Random
             {
                 if (options.Filename.Contains("\\") && !Directory.Exists(options.Filename.Substring(0, options.Filename.LastIndexOf('\\'))))
                 {
-                    Directory.CreateDirectory(options.Filename.Substring(0, options.Filename.LastIndexOf('\\')));
+                    String filePath = FileName.Fix(options.Filename, string.Format(romLocations.SeedFileString, seed), complexity);
+                    Directory.CreateDirectory(filePath.Substring(0, filePath.LastIndexOf('\\')));
                 }
 
                 if (!options.NoRandomization)

--- a/AlttpRandomizer/Random/Randomizer.cs
+++ b/AlttpRandomizer/Random/Randomizer.cs
@@ -73,9 +73,9 @@ namespace AlttpRandomizer.Random
         {
             try
             {
-                if (options.Filename.Contains("\\") && !Directory.Exists(options.Filename.Substring(0, options.Filename.LastIndexOf('\\'))))
+                String filePath = FileName.Fix(options.Filename, string.Format(romLocations.SeedFileString, seed), complexity);
+                if (filePath.Contains("\\") && !Directory.Exists(filePath.Substring(0, filePath.LastIndexOf('\\'))))
                 {
-                    String filePath = FileName.Fix(options.Filename, string.Format(romLocations.SeedFileString, seed), complexity);
                     Directory.CreateDirectory(filePath.Substring(0, filePath.LastIndexOf('\\')));
                 }
 

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -102,14 +102,12 @@ namespace AlttpRandomizer.Rom
                     NeverItems = { InventoryItemType.BigKey, InventoryItemType.Key },
                     CanAccess =
                         have =>
-                        CanEnterSwampPalace(have) 
+                        CanEnterSwampPalace(have)
                         && have.Contains(InventoryItemType.Hammer)
-                        && (LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
-                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - map room", InventoryItemType.BigKey)
-                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - push 4 blocks room", InventoryItemType.BigKey)
-                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey)
-                            || (have.Contains(InventoryItemType.Hookshot) 
-                                && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest",InventoryItemType.Hookshot)))
+                        && (have.Contains(InventoryItemType.Hookshot)
+                            || (!LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [left chest]",InventoryItemType.BigKey)
+                                && !LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [right chest]",InventoryItemType.BigKey)
+                                && !LocationHasItem("[dungeon-D2-B2] Swamp Palace - hidden waterfall door room",InventoryItemType.BigKey))),
                 },
                 new Location
                 {
@@ -1193,8 +1191,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
-                        && have.Contains(InventoryItemType.Hookshot)
-                        && have.Contains(InventoryItemType.Hammer),
+                        && CanAccessLateSwampPalace(have),
                 },
                 new Location
                 {
@@ -1205,8 +1202,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
-                        && have.Contains(InventoryItemType.Hookshot)
-                        && have.Contains(InventoryItemType.Hammer),
+                        && CanAccessLateSwampPalace(have),
                 },
                 new Location
                 {
@@ -1217,8 +1213,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
-                        && have.Contains(InventoryItemType.Hookshot)
-                        && have.Contains(InventoryItemType.Hammer),
+                        && CanAccessLateSwampPalace(have),
                 },
                 new Location
                 {
@@ -2094,6 +2089,7 @@ namespace AlttpRandomizer.Rom
                 new Location
                 {
                     Name = "Magic Bat",
+                    Region = Region.LightWorld,
                     Address = 0x180015,
                     CanAccess =
                         have =>
@@ -2637,6 +2633,17 @@ namespace AlttpRandomizer.Rom
                             || LocationHasItem("[dungeon-D1-1F] Dark Palace - jump room [right chest]", InventoryItemType.Key) 
                             || LocationHasItem("[dungeon-D1-1F] Dark Palace - jump room [left chest]", InventoryItemType.Key) 
                             || LocationHasItem("[dungeon-D1-B1] Dark Palace - turtle stalfos room", InventoryItemType.Key))));
+        }
+
+        private bool CanAccessLateSwampPalace(List<InventoryItemType> have)
+        {
+            return (have.Contains(InventoryItemType.Hammer)
+                    && (LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
+                        || LocationHasItem("[dungeon-D2-B1] Swamp Palace - map room", InventoryItemType.BigKey)
+                        || LocationHasItem("[dungeon-D2-B1] Swamp Palace - push 4 blocks room", InventoryItemType.BigKey)
+                        || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey)
+                        || (have.Contains(InventoryItemType.Hookshot)
+                            && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest", InventoryItemType.Hookshot))));
         }
 
         private bool CanAccessZorasRiver(List<InventoryItemType> have)

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -104,11 +104,12 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterSwampPalace(have) 
                         && have.Contains(InventoryItemType.Hammer)
-                        && ((LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
+                        && (LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
                                 || LocationHasItem("[dungeon-D2-B1] Swamp Palace - map room", InventoryItemType.BigKey)
                                 || LocationHasItem("[dungeon-D2-B1] Swamp Palace - push 4 blocks room", InventoryItemType.BigKey)
-                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey))
-                            || (have.Contains(InventoryItemType.Hookshot) && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest",InventoryItemType.Hookshot)))
+                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey)
+                            || (have.Contains(InventoryItemType.Hookshot) 
+                                && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest",InventoryItemType.Hookshot)))
                 },
                 new Location
                 {

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -2680,7 +2680,11 @@ namespace AlttpRandomizer.Rom
             };
 
             // return true if crystals 5 and 6 are accessible
-            return dungeons.Keys.Where(key => CrystalAtLocation(key, CrystalItemType.Crystal5) || CrystalAtLocation(key, CrystalItemType.Crystal6)).All(key => dungeons[key](have));
+            return dungeons.Keys.Where(key => CrystalAtLocation(key, CrystalItemType.Crystal5) || CrystalAtLocation(key, CrystalItemType.Crystal6)).All(key => dungeons[key](have))
+                && have.Contains(InventoryItemType.MoonPearl)
+                && (have.Contains(InventoryItemType.Hammer)
+                    || (CanDefeatAgahnim1(have) 
+                        && have.Contains(InventoryItemType.MagicMirror)));
         }
 
         private bool CanGetMasterSword(List<InventoryItemType> have)

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -103,11 +103,12 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have) 
-                        && have.Contains(InventoryItemType.Hammer) 
-                        && (have.Contains(InventoryItemType.Hookshot) 
-                            | (!LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [left chest]",InventoryItemType.BigKey) 
-                                && !LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [right chest]",InventoryItemType.BigKey)   
-                                && !LocationHasItem("[dungeon-D2-B2] Swamp Palace - hidden waterfall door room",InventoryItemType.BigKey))),
+                        && have.Contains(InventoryItemType.Hammer)
+                        && ((LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
+                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - map room", InventoryItemType.BigKey)
+                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - push 4 blocks room", InventoryItemType.BigKey)
+                                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey))
+                            || (have.Contains(InventoryItemType.Hookshot) && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest",InventoryItemType.Hookshot)))
                 },
                 new Location
                 {

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -105,7 +105,7 @@ namespace AlttpRandomizer.Rom
                         CanEnterSwampPalace(have) 
                         && have.Contains(InventoryItemType.Hammer) 
                         && (have.Contains(InventoryItemType.Hookshot) 
-                            || (!LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [left chest]",InventoryItemType.BigKey) 
+                            | (!LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [left chest]",InventoryItemType.BigKey) 
                                 && !LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [right chest]",InventoryItemType.BigKey)   
                                 && !LocationHasItem("[dungeon-D2-B2] Swamp Palace - hidden waterfall door room",InventoryItemType.BigKey))),
                 },
@@ -691,6 +691,7 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterTurtleRock(have)
                         && CanAccessTurtleRock2(have)
+                        && have.Contains(InventoryItemType.Lamp)
                         && (have.Contains(InventoryItemType.FireRod)
                             || (LocationHasItem("[dungeon-D7-1F] Turtle Rock - compass room", InventoryItemType.Key)
                                 && LocationHasItem("[dungeon-D7-1F] Turtle Rock - Chain chomp room", InventoryItemType.Key)
@@ -707,6 +708,7 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterTurtleRock(have)
                         && CanAccessTurtleRock2(have)
+                        && have.Contains(InventoryItemType.Lamp)
                         && (have.Contains(InventoryItemType.FireRod)
                             || (LocationHasItem("[dungeon-D7-1F] Turtle Rock - compass room", InventoryItemType.Key)
                                 && LocationHasItem("[dungeon-D7-1F] Turtle Rock - Chain chomp room", InventoryItemType.Key)
@@ -723,6 +725,7 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterTurtleRock(have)
                         && CanAccessTurtleRock2(have)
+                        && have.Contains(InventoryItemType.Lamp)
                         && (have.Contains(InventoryItemType.FireRod)
                             || (LocationHasItem("[dungeon-D7-1F] Turtle Rock - compass room", InventoryItemType.Key)
                                 && LocationHasItem("[dungeon-D7-1F] Turtle Rock - Chain chomp room", InventoryItemType.Key)
@@ -739,6 +742,7 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterTurtleRock(have)
                         && CanAccessTurtleRock2(have)
+                        && have.Contains(InventoryItemType.Lamp)
                         && (have.Contains(InventoryItemType.FireRod)
                             || (LocationHasItem("[dungeon-D7-1F] Turtle Rock - compass room", InventoryItemType.Key)
                                 && LocationHasItem("[dungeon-D7-1F] Turtle Rock - Chain chomp room", InventoryItemType.Key)
@@ -755,6 +759,7 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterTurtleRock(have)
                         && CanAccessTurtleRock2(have)
+                        && have.Contains(InventoryItemType.Lamp)
                         && (have.Contains(InventoryItemType.FireRod)
                             || (LocationHasItem("[dungeon-D7-1F] Turtle Rock - compass room", InventoryItemType.Key)
                                 && LocationHasItem("[dungeon-D7-1F] Turtle Rock - Chain chomp room", InventoryItemType.Key)
@@ -2210,6 +2215,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanAccessNorthWestDarkWorld(have)
+                        && CanLiftLightRocks(have)
                         && have.Contains(InventoryItemType.Cape),
                 },
                 new Location
@@ -2941,8 +2947,9 @@ namespace AlttpRandomizer.Rom
         protected override bool CanDefeatTowerOfHera(List<InventoryItemType> have)
         {
             return CanEnterTowerOfHera(have)
-                && (!LocationHasItem("[dungeon-L3-1F] Tower of Hera - first floor", InventoryItemType.BigKey)
-                    || CanLightTorches(have));
+                && ((LocationHasItem("[dungeon-L3-1F] Tower of Hera - first floor", InventoryItemType.BigKey)
+                        && CanLightTorches(have))
+                   || LocationHasItem("[dungeon-L3-2F] Tower of Hera - Entrance", InventoryItemType.BigKey));
         }
 
         protected override bool CanDefeatDesertPalace(List<InventoryItemType> have)

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -2802,6 +2802,7 @@ namespace AlttpRandomizer.Rom
             return CanEnterTurtleRock(have)
                 && CanAccessTurtleRock2(have)
                 && TurtleRockKeysOkay()
+                && have.Contains(InventoryItemType.Lamp)
                 && have.Contains(InventoryItemType.FireRod)
                 && have.Contains(InventoryItemType.IceRod);
         }


### PR DESCRIPTION
Looking at the bug fixes, I created a fork of the project and coded a few of the fixes myself, at the very least as a means to learn more about the project and improve my on C# skills and in case anyone found any use from it.

-Fixed crash caused by using <seed> or <date> in a folder name for the ROM File (Issue #279
-Fixed the logic for the chests in the Eye bridge room at the end of Turtle Rock to prevent the Lamp from spawning here (Issue #274)
-Added CanLiftLightRocks(have) as a requirement for the BumperCave, since CanAccessNorthwestDarkWorld(have) can evaluate to true without having the ability to lift light rocks (as it should) (Issue #281)
-Updated CanDefeatHera(have) so that it will check if you can light torches if the big key is in the 1F chest, this will help with issues where Moldorm could have the Fire Rod (or possibly the Lamp) which could prevent you from reaching him. (Issue #266)
-Updated the logic for the Big Chest in Swamp Palace to cover a more broad spectrum of big key locations than it originally covered to help ensure it can be opened. (Issue #267)