### PR TITLE
Additional Bug Fixes

### DIFF
--- a/AlttpRandomizer/MainForm.Designer.cs
+++ b/AlttpRandomizer/MainForm.Designer.cs
@@ -59,9 +59,10 @@
             // 
             this.createSpoilerLog.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.createSpoilerLog.AutoSize = true;
-            this.createSpoilerLog.Location = new System.Drawing.Point(179, 110);
+            this.createSpoilerLog.Location = new System.Drawing.Point(271, 169);
+            this.createSpoilerLog.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.createSpoilerLog.Name = "createSpoilerLog";
-            this.createSpoilerLog.Size = new System.Drawing.Size(113, 17);
+            this.createSpoilerLog.Size = new System.Drawing.Size(167, 24);
             this.createSpoilerLog.TabIndex = 32;
             this.createSpoilerLog.Text = "Create Spoiler Log";
             this.createSpoilerLog.UseVisualStyleBackColor = true;
@@ -69,9 +70,10 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(6, 22);
+            this.label5.Location = new System.Drawing.Point(9, 34);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(50, 13);
+            this.label5.Size = new System.Drawing.Size(73, 20);
             this.label5.TabIndex = 31;
             this.label5.Text = "Difficulty:";
             // 
@@ -83,18 +85,20 @@
             "Casual",
             "Glitched",
             "No Randomization"});
-            this.randomizerDifficulty.Location = new System.Drawing.Point(62, 19);
+            this.randomizerDifficulty.Location = new System.Drawing.Point(93, 29);
+            this.randomizerDifficulty.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.randomizerDifficulty.Name = "randomizerDifficulty";
-            this.randomizerDifficulty.Size = new System.Drawing.Size(128, 21);
+            this.randomizerDifficulty.Size = new System.Drawing.Size(190, 28);
             this.randomizerDifficulty.TabIndex = 30;
             this.randomizerDifficulty.SelectedIndexChanged += new System.EventHandler(this.randomizerDifficulty_SelectedIndexChanged);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 16);
+            this.label3.Location = new System.Drawing.Point(9, 25);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(242, 13);
+            this.label3.Size = new System.Drawing.Size(358, 20);
             this.label3.TabIndex = 28;
             this.label3.Text = "Seed (leave blank to generate new random ROM)";
             // 
@@ -105,12 +109,13 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.output.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.output.Location = new System.Drawing.Point(12, 183);
+            this.output.Location = new System.Drawing.Point(18, 282);
+            this.output.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.output.Multiline = true;
             this.output.Name = "output";
             this.output.ReadOnly = true;
             this.output.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.output.Size = new System.Drawing.Size(600, 216);
+            this.output.Size = new System.Drawing.Size(898, 330);
             this.output.TabIndex = 22;
             this.output.WordWrap = false;
             // 
@@ -118,17 +123,20 @@
             // 
             this.seed.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.seed.Location = new System.Drawing.Point(9, 32);
+            this.seed.Location = new System.Drawing.Point(14, 49);
+            this.seed.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.seed.Name = "seed";
-            this.seed.Size = new System.Drawing.Size(383, 20);
+            this.seed.Size = new System.Drawing.Size(572, 26);
             this.seed.TabIndex = 27;
+            this.seed.TextChanged += new System.EventHandler(this.seed_TextChanged);
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(6, 55);
+            this.label4.Location = new System.Drawing.Point(9, 85);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(385, 13);
+            this.label4.Size = new System.Drawing.Size(575, 20);
             this.label4.TabIndex = 24;
             this.label4.Text = "Output Filename (<seed> is replaced with file seed, <date> is replaced with date)" +
     "";
@@ -137,9 +145,10 @@
             // 
             this.filename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.filename.Location = new System.Drawing.Point(9, 71);
+            this.filename.Location = new System.Drawing.Point(14, 109);
+            this.filename.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.filename.Name = "filename";
-            this.filename.Size = new System.Drawing.Size(352, 20);
+            this.filename.Size = new System.Drawing.Size(526, 26);
             this.filename.TabIndex = 25;
             this.filename.Text = "ALttP Random <seed>.sfc";
             this.filename.TextChanged += new System.EventHandler(this.filename_TextChanged);
@@ -148,9 +157,10 @@
             // sramTrace
             // 
             this.sramTrace.AutoSize = true;
-            this.sramTrace.Location = new System.Drawing.Point(6, 73);
+            this.sramTrace.Location = new System.Drawing.Point(9, 112);
+            this.sramTrace.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.sramTrace.Name = "sramTrace";
-            this.sramTrace.Size = new System.Drawing.Size(88, 17);
+            this.sramTrace.Size = new System.Drawing.Size(126, 24);
             this.sramTrace.TabIndex = 35;
             this.sramTrace.Text = "SRAM Trace";
             this.sramTrace.UseVisualStyleBackColor = true;
@@ -164,9 +174,11 @@
             this.groupBox1.Controls.Add(this.label5);
             this.groupBox1.Controls.Add(this.randomizerDifficulty);
             this.groupBox1.Controls.Add(this.sramTrace);
-            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Location = new System.Drawing.Point(18, 18);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(196, 165);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox1.Size = new System.Drawing.Size(294, 254);
             this.groupBox1.TabIndex = 37;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Randomizer Options";
@@ -176,9 +188,10 @@
             this.showComplexity.AutoSize = true;
             this.showComplexity.Checked = true;
             this.showComplexity.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.showComplexity.Location = new System.Drawing.Point(6, 96);
+            this.showComplexity.Location = new System.Drawing.Point(9, 148);
+            this.showComplexity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.showComplexity.Name = "showComplexity";
-            this.showComplexity.Size = new System.Drawing.Size(106, 17);
+            this.showComplexity.Size = new System.Drawing.Size(155, 24);
             this.showComplexity.TabIndex = 39;
             this.showComplexity.Text = "Show Complexity";
             this.showComplexity.UseVisualStyleBackColor = true;
@@ -186,9 +199,10 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 49);
+            this.label1.Location = new System.Drawing.Point(9, 75);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(98, 13);
+            this.label1.Size = new System.Drawing.Size(146, 20);
             this.label1.TabIndex = 38;
             this.label1.Text = "Heart Beep Speed:";
             // 
@@ -201,17 +215,19 @@
             "Normal",
             "Half",
             "Quarter"});
-            this.heartBeepSpeed.Location = new System.Drawing.Point(110, 46);
+            this.heartBeepSpeed.Location = new System.Drawing.Point(165, 71);
+            this.heartBeepSpeed.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.heartBeepSpeed.Name = "heartBeepSpeed";
-            this.heartBeepSpeed.Size = new System.Drawing.Size(80, 21);
+            this.heartBeepSpeed.Size = new System.Drawing.Size(118, 28);
             this.heartBeepSpeed.TabIndex = 37;
             // 
             // checkForUpdates
             // 
             this.checkForUpdates.AutoSize = true;
-            this.checkForUpdates.Location = new System.Drawing.Point(6, 142);
+            this.checkForUpdates.Location = new System.Drawing.Point(9, 218);
+            this.checkForUpdates.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.checkForUpdates.Name = "checkForUpdates";
-            this.checkForUpdates.Size = new System.Drawing.Size(167, 17);
+            this.checkForUpdates.Size = new System.Drawing.Size(247, 24);
             this.checkForUpdates.TabIndex = 36;
             this.checkForUpdates.Text = "Check for Updates on Startup";
             this.checkForUpdates.UseVisualStyleBackColor = true;
@@ -230,23 +246,26 @@
             this.groupBox2.Controls.Add(this.seed);
             this.groupBox2.Controls.Add(this.browse);
             this.groupBox2.Controls.Add(this.create);
-            this.groupBox2.Location = new System.Drawing.Point(214, 12);
+            this.groupBox2.Location = new System.Drawing.Point(321, 18);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(398, 165);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox2.Size = new System.Drawing.Size(597, 254);
             this.groupBox2.TabIndex = 38;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "File Options";
             // 
             // bulkCreateCount
             // 
-            this.bulkCreateCount.Location = new System.Drawing.Point(9, 137);
+            this.bulkCreateCount.Location = new System.Drawing.Point(14, 211);
+            this.bulkCreateCount.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.bulkCreateCount.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.bulkCreateCount.Name = "bulkCreateCount";
-            this.bulkCreateCount.Size = new System.Drawing.Size(44, 20);
+            this.bulkCreateCount.Size = new System.Drawing.Size(66, 26);
             this.bulkCreateCount.TabIndex = 38;
             this.bulkCreateCount.Value = new decimal(new int[] {
             5,
@@ -258,9 +277,10 @@
             // 
             this.bulkCreate.Image = global::AlttpRandomizer.Properties.Resources.bulk_checkmark;
             this.bulkCreate.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.bulkCreate.Location = new System.Drawing.Point(59, 135);
+            this.bulkCreate.Location = new System.Drawing.Point(88, 208);
+            this.bulkCreate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.bulkCreate.Name = "bulkCreate";
-            this.bulkCreate.Size = new System.Drawing.Size(93, 24);
+            this.bulkCreate.Size = new System.Drawing.Size(140, 37);
             this.bulkCreate.TabIndex = 37;
             this.bulkCreate.Text = "Bulk Create";
             this.bulkCreate.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -272,9 +292,10 @@
             this.listSpoiler.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.listSpoiler.Image = global::AlttpRandomizer.Properties.Resources.bulleted_list_options;
             this.listSpoiler.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.listSpoiler.Location = new System.Drawing.Point(298, 135);
+            this.listSpoiler.Location = new System.Drawing.Point(447, 208);
+            this.listSpoiler.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.listSpoiler.Name = "listSpoiler";
-            this.listSpoiler.Size = new System.Drawing.Size(93, 24);
+            this.listSpoiler.Size = new System.Drawing.Size(140, 37);
             this.listSpoiler.TabIndex = 36;
             this.listSpoiler.Text = "List Spoiler";
             this.listSpoiler.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -285,9 +306,10 @@
             // 
             this.browse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.browse.Image = global::AlttpRandomizer.Properties.Resources.MenuFileSaveIcon;
-            this.browse.Location = new System.Drawing.Point(367, 68);
+            this.browse.Location = new System.Drawing.Point(550, 105);
+            this.browse.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.browse.Name = "browse";
-            this.browse.Size = new System.Drawing.Size(25, 25);
+            this.browse.Size = new System.Drawing.Size(38, 38);
             this.browse.TabIndex = 26;
             this.browse.UseVisualStyleBackColor = true;
             this.browse.Click += new System.EventHandler(this.browse_Click);
@@ -297,9 +319,10 @@
             this.create.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.create.Image = global::AlttpRandomizer.Properties.Resources.base_checkmark;
             this.create.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.create.Location = new System.Drawing.Point(298, 105);
+            this.create.Location = new System.Drawing.Point(447, 162);
+            this.create.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.create.Name = "create";
-            this.create.Size = new System.Drawing.Size(93, 24);
+            this.create.Size = new System.Drawing.Size(140, 37);
             this.create.TabIndex = 23;
             this.create.Text = "Create";
             this.create.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -311,9 +334,10 @@
             this.randomSpoiler.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.randomSpoiler.Image = global::AlttpRandomizer.Properties.Resources._112_RefreshArrow_Blue;
             this.randomSpoiler.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.randomSpoiler.Location = new System.Drawing.Point(12, 405);
+            this.randomSpoiler.Location = new System.Drawing.Point(18, 623);
+            this.randomSpoiler.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.randomSpoiler.Name = "randomSpoiler";
-            this.randomSpoiler.Size = new System.Drawing.Size(122, 24);
+            this.randomSpoiler.Size = new System.Drawing.Size(183, 37);
             this.randomSpoiler.TabIndex = 34;
             this.randomSpoiler.Text = "Random Spoiler";
             this.randomSpoiler.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -325,9 +349,10 @@
             this.report.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.report.Image = global::AlttpRandomizer.Properties.Resources.base_exclamationmark;
             this.report.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.report.Location = new System.Drawing.Point(480, 405);
+            this.report.Location = new System.Drawing.Point(720, 623);
+            this.report.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.report.Name = "report";
-            this.report.Size = new System.Drawing.Size(132, 24);
+            this.report.Size = new System.Drawing.Size(198, 37);
             this.report.TabIndex = 33;
             this.report.Text = "Report an issue";
             this.report.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -336,15 +361,16 @@
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(624, 441);
+            this.ClientSize = new System.Drawing.Size(936, 678);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.randomSpoiler);
             this.Controls.Add(this.report);
             this.Controls.Add(this.output);
-            this.MinimumSize = new System.Drawing.Size(640, 480);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.MinimumSize = new System.Drawing.Size(949, 708);
             this.Name = "MainForm";
             this.Text = "A Link to the Past Randomizer";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);

--- a/AlttpRandomizer/MainForm.cs
+++ b/AlttpRandomizer/MainForm.cs
@@ -501,15 +501,59 @@ namespace AlttpRandomizer
 
         private void randomizerDifficulty_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (randomizerDifficulty.SelectedItem.ToString() == "No Randomization")
+            switch(randomizerDifficulty.SelectedItem.ToString())
             {
-                seed.Text = "NORAND";
-                bulkCreate.Enabled = false;
+                case "Casual":
+                    bulkCreate.Enabled = true;
+                    if (seed.Text.ToUpper().StartsWith("G"))
+                    {
+                        seed.Text = seed.Text.ToUpper().Replace('G', 'C');
+                    }
+                    else if (seed.Text.ToUpper() == "NORAND")
+                    {
+                        seed.Text = "";
+                    }
+                    break;
+                case "Glitched":
+                    bulkCreate.Enabled = true;
+                    if (seed.Text.ToUpper().StartsWith("C"))
+                    {
+                        seed.Text = seed.Text.ToUpper().Replace('C', 'G');
+                    }
+                    else if (seed.Text.ToUpper() == "NORAND")
+                    {
+                        seed.Text = "";
+                    }
+                    break;
+                case "No Randomization":
+                    seed.Text = "NORAND";
+                    bulkCreate.Enabled = false;
+                    break;
             }
-            else if (seed.Text == "NORAND")
+        }
+
+        private void seed_TextChanged(object sender, EventArgs e)
+        {
+            if(seed.Text.ToUpper().StartsWith("C"))
             {
-                seed.Text = "";
-                bulkCreate.Enabled = true;
+                if (randomizerDifficulty.SelectedItem.ToString() != "Casual")
+                {
+                    randomizerDifficulty.SelectedItem = "Casual";
+                }
+            }
+            else if (seed.Text.ToUpper().StartsWith("G"))
+            {
+                if (randomizerDifficulty.SelectedItem.ToString() != "Glitched")
+                {
+                    randomizerDifficulty.SelectedItem = "Glitched";
+                }
+            }
+            else if (seed.Text.ToUpper() == "NORAND")
+            {
+                if (randomizerDifficulty.SelectedItem.ToString() != "No Randomization")
+                {
+                    randomizerDifficulty.SelectedItem = "No Randomization";
+                }
             }
         }
     }

--- a/AlttpRandomizer/MainForm.cs
+++ b/AlttpRandomizer/MainForm.cs
@@ -492,6 +492,8 @@ namespace AlttpRandomizer
                 {
                     WriteOutput(string.Format(", {0} failed. ", failCount));
                 }
+                MessageBox.Show(string.Format("Completed! {0} successful", successCount) + " and " +
+                    string.Format(", {0} failed. ", failCount), "Bulk Creation Complete", MessageBoxButtons.OK);
             }
 
             SaveRandomizerSettings();

--- a/AlttpRandomizer/Rom/BaseRomLocations.cs
+++ b/AlttpRandomizer/Rom/BaseRomLocations.cs
@@ -13,6 +13,10 @@ namespace AlttpRandomizer.Rom
         public virtual List<Location> Locations { get; set; }
         public virtual List<Location> SpecialLocations { get; set; }
 
+        private static int RegionCount = System.Enum.GetValues(typeof(Region)).Length;
+
+        public bool[] DungeonHasBigKey = new bool[RegionCount];
+
         private static void WeightLocations(List<Location> retVal)
         {
             var currentWeight = (from item in retVal orderby item.Weight descending select item.Weight).First() + 1;
@@ -85,6 +89,8 @@ namespace AlttpRandomizer.Rom
         public void ResetRegion(Region region)
         {
             var locations = (from Location location in Locations where (location.Region == region) select location).ToList();
+
+            DungeonHasBigKey[(int)region] = false;
 
             foreach (var location in locations)
             {
@@ -164,6 +170,11 @@ namespace AlttpRandomizer.Rom
 
                 if (!(badLateGameItemSpot || badFirstItemSpot || badNeverItemSpot))
                 {
+                    if (insertedItem == InventoryItemType.BigKey)
+                    {
+                        DungeonHasBigKey[(int)currentLocations[0].Region] = true;
+                    }
+
                     return currentLocations.IndexOf(location);
                 }
             }

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -953,7 +953,9 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterMiseryMire(have)
-                        && CanLightTorches(have),
+                        && CanLightTorches(have)
+                        && (!LocationHasItem("[dungeon-D6-B1] Misery Mire - big chest", InventoryItemType.Key)
+                            || LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.Key)),
                 },
                 new Location
                 {
@@ -988,7 +990,9 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterMiseryMire(have)
-                        && CanLightTorches(have),
+                        && CanLightTorches(have)
+                        && (!LocationHasItem("[dungeon-D6-B1] Misery Mire - big chest", InventoryItemType.Key)
+                            || LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.Key)),
                 },
 
                 new Location
@@ -2759,6 +2763,8 @@ namespace AlttpRandomizer.Rom
         protected override bool CanDefeatSkullWoods(List<InventoryItemType> have)
         {
             return CanEnterSkullWoods2(have);
+                && !(LocationHasItem("[dungeon-D3-B1] Skull Woods - big chest", InventoryItemType.FireRod)
+                    && LocationHasItem("[dungeon-D3-B1] Skull Woods - Entrance to part 2", InventoryItemType.BigKey));
         }
 
         protected override bool CanDefeatThievesTown(List<InventoryItemType> have)

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -81,7 +81,7 @@ namespace AlttpRandomizer.Rom
                     NeverItems = { InventoryItemType.BigKey, InventoryItemType.Key },
                     CanAccess =
                         have =>
-                        true,
+                        DungeonHasBigKey[(int)Region.EasternPalace],
                 },
                 new Location
                 {
@@ -103,6 +103,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
+                        && DungeonHasBigKey[(int)Region.SwampPalace]
                         && have.Contains(InventoryItemType.Hammer)
                         && (have.Contains(InventoryItemType.Hookshot)
                             || (!LocationHasItem("[dungeon-D2-B2] Swamp Palace - flooded room [left chest]",InventoryItemType.BigKey)
@@ -129,6 +130,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterDesertPalace(have)
+                        && DungeonHasBigKey[(int)Region.DesertPalace]
                         && (have.Contains(InventoryItemType.PegasusBoots)
                             || LocationHasItem("[dungeon-L2-B1] Desert Palace - Map room", InventoryItemType.BigKey)),
                 },
@@ -161,7 +163,8 @@ namespace AlttpRandomizer.Rom
                     NeverItems = { InventoryItemType.BigKey, InventoryItemType.Key },
                     CanAccess =
                         have =>
-                        CanEnterSkullWoods(have) 
+                        CanEnterSkullWoods(have)
+                        && DungeonHasBigKey[(int)Region.SkullWoods]
                         && (have.Contains(InventoryItemType.FireRod) 
                             || !LocationHasItem("[dungeon-D3-B1] Skull Woods - Entrance to part 2", InventoryItemType.BigKey)),
                 },
@@ -224,6 +227,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterIcePalace(have)
+                        && DungeonHasBigKey[(int)Region.IcePalace]
                         && (LocationHasItem("[dungeon-D5-B1] Ice Palace - compass room", InventoryItemType.BigKey)
                             || LocationHasItem("[dungeon-D5-B4] Ice Palace - above Blue Mail room", InventoryItemType.BigKey)
                             || LocationHasItem("[dungeon-D5-B5] Ice Palace - b5 up staircase", InventoryItemType.BigKey)
@@ -505,6 +509,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterTowerOfHera(have)
+                        && DungeonHasBigKey[(int)Region.TowerOfHera]
                         && (CanLightTorches(have)
                             || LocationHasItem("[dungeon-L3-2F] Tower of Hera - Entrance", InventoryItemType.BigKey)),
                 },
@@ -592,6 +597,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterThievesTown(have)
+                        && DungeonHasBigKey[(int)Region.ThievesTown]
                         && have.Contains(InventoryItemType.Hammer),
                 },
                 new Location
@@ -629,6 +635,7 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterTurtleRock(have)
                         && CanAccessTurtleRock2(have)
+                        && DungeonHasBigKey[(int)Region.TurtleRock]
                         && (have.Contains(InventoryItemType.FireRod)
                             || (LocationHasItem("[dungeon-D7-1F] Turtle Rock - compass room", InventoryItemType.Key)
                                 && LocationHasItem("[dungeon-D7-1F] Turtle Rock - Chain chomp room", InventoryItemType.Key)
@@ -825,6 +832,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanAccessLateDarkPalace(have)
+                        && DungeonHasBigKey[(int)Region.DarkPalace]
                         && have.Contains(InventoryItemType.Lamp),
                 },
                 new Location
@@ -953,9 +961,11 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterMiseryMire(have)
-                        && CanLightTorches(have)
-                        && (!LocationHasItem("[dungeon-D6-B1] Misery Mire - big chest", InventoryItemType.Key)
-                            || LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.Key)),
+                        && DungeonHasBigKey[(int)Region.MiseryMire]
+                        && ((!LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.BigKey)
+                                && !LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.BigKey))
+                            || (CanLightTorches(have)
+                                && MiseryMireAccessibleKeyCount())),
                 },
                 new Location
                 {
@@ -967,6 +977,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterMiseryMire(have)
+                        && DungeonHasBigKey[(int)Region.MiseryMire]
                         && (CanLightTorches(have)
                             || (!LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.BigKey)
                                 && !LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.BigKey))),
@@ -1195,7 +1206,8 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
-                        && CanAccessLateSwampPalace(have),
+                        && have.Contains(InventoryItemType.Hookshot)
+                        && have.Contains(InventoryItemType.Hammer),
                 },
                 new Location
                 {
@@ -1206,7 +1218,8 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
-                        && CanAccessLateSwampPalace(have),
+                        && have.Contains(InventoryItemType.Hookshot)
+                        && have.Contains(InventoryItemType.Hammer),
                 },
                 new Location
                 {
@@ -1217,7 +1230,8 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterSwampPalace(have)
-                        && CanAccessLateSwampPalace(have),
+                        && have.Contains(InventoryItemType.Hookshot)
+                        && have.Contains(InventoryItemType.Hammer),
                 },
                 new Location
                 {
@@ -1350,7 +1364,8 @@ namespace AlttpRandomizer.Rom
                     NeverItems = { InventoryItemType.BigKey, InventoryItemType.Key },
                     CanAccess =
                         have =>
-                        CanEnterGanonsTower(have),
+                        CanEnterGanonsTower(have)
+                        && DungeonHasBigKey[(int)Region.GanonsTower],
                 },
                 new Location
                 {
@@ -2639,16 +2654,16 @@ namespace AlttpRandomizer.Rom
                             || LocationHasItem("[dungeon-D1-B1] Dark Palace - turtle stalfos room", InventoryItemType.Key))));
         }
 
-        private bool CanAccessLateSwampPalace(List<InventoryItemType> have)
-        {
-            return (have.Contains(InventoryItemType.Hammer)
-                    && (LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
-                        || LocationHasItem("[dungeon-D2-B1] Swamp Palace - map room", InventoryItemType.BigKey)
-                        || LocationHasItem("[dungeon-D2-B1] Swamp Palace - push 4 blocks room", InventoryItemType.BigKey)
-                        || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey)
-                        || (have.Contains(InventoryItemType.Hookshot)
-                            && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest", InventoryItemType.Hookshot))));
-        }
+        //private bool CanAccessLateSwampPalace(List<InventoryItemType> have)
+        //{
+        //    return (have.Contains(InventoryItemType.Hammer)
+        //            && (LocationHasItem("[dungeon-D2-B1] Swamp Palace - big key room", InventoryItemType.BigKey)
+        //                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - map room", InventoryItemType.BigKey)
+        //                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - push 4 blocks room", InventoryItemType.BigKey)
+        //                || LocationHasItem("[dungeon-D2-B1] Swamp Palace - south of hookshot room", InventoryItemType.BigKey)
+        //                || (have.Contains(InventoryItemType.Hookshot)
+        //                    && !LocationHasItem("[dungeon-D2-B1] Swamp Palace - big chest", InventoryItemType.Hookshot))));
+        //}
 
         private bool CanAccessZorasRiver(List<InventoryItemType> have)
         {
@@ -2776,6 +2791,7 @@ namespace AlttpRandomizer.Rom
         {
             return CanEnterIcePalace(have)
                 && have.Contains(InventoryItemType.Hammer)
+                && DungeonHasBigKey[(int)Region.IcePalace]
                 && ((LocationHasItem("[dungeon-D5-B1] Ice Palace - compass room", InventoryItemType.BigKey)
                         && LocationHasItem("[dungeon-D5-B4] Ice Palace - above Blue Mail room", InventoryItemType.Key)
                         && LocationHasItem("[dungeon-D5-B5] Ice Palace - b5 up staircase", InventoryItemType.Key))
@@ -2812,6 +2828,18 @@ namespace AlttpRandomizer.Rom
                 || LocationHasItem("[dungeon-D6-B1] Misery Mire - spike room", InventoryItemType.Key)
                 || LocationHasItem("[dungeon-D6-B1] Misery Mire - end of bridge", InventoryItemType.BigKey)
                 || LocationHasItem("[dungeon-D6-B1] Misery Mire - end of bridge", InventoryItemType.Key);
+        }
+
+        private bool MiseryMireAccessibleKeyCount()
+        {
+            var accessibleKeyCount = 0;
+
+            if (LocationHasItem("[dungeon-D6-B1] Misery Mire - big hub room", InventoryItemType.Key)) { accessibleKeyCount++; }
+            if (LocationHasItem("[dungeon-D6-B1] Misery Mire - end of bridge", InventoryItemType.Key)) { accessibleKeyCount++; }
+            if (LocationHasItem("[dungeon-D6-B1] Misery Mire - map room", InventoryItemType.Key)) { accessibleKeyCount++; }
+            if (LocationHasItem("[dungeon-D6-B1] Misery Mire - spike room", InventoryItemType.Key)) { accessibleKeyCount++; }
+
+            return accessibleKeyCount >= 2;
         }
 
         protected override bool CanDefeatTurtleRock(List<InventoryItemType> have)
@@ -2967,9 +2995,9 @@ namespace AlttpRandomizer.Rom
         protected override bool CanDefeatTowerOfHera(List<InventoryItemType> have)
         {
             return CanEnterTowerOfHera(have)
-                && ((LocationHasItem("[dungeon-L3-1F] Tower of Hera - first floor", InventoryItemType.BigKey)
-                        && CanLightTorches(have))
-                   || LocationHasItem("[dungeon-L3-2F] Tower of Hera - Entrance", InventoryItemType.BigKey));
+                && DungeonHasBigKey[(int)Region.TowerOfHera]
+                && (!LocationHasItem("[dungeon-L3-1F] Tower of Hera - first floor", InventoryItemType.BigKey)
+                    || CanLightTorches(have));
         }
 
         protected override bool CanDefeatDesertPalace(List<InventoryItemType> have)

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -961,11 +961,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterMiseryMire(have)
-                        && DungeonHasBigKey[(int)Region.MiseryMire]
-                        && ((!LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.BigKey)
-                                && !LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.BigKey))
-                            || (CanLightTorches(have)
-                                && MiseryMireAccessibleKeyCount())),
+                        && CanLightTorches(have),
                 },
                 new Location
                 {
@@ -978,9 +974,10 @@ namespace AlttpRandomizer.Rom
                         have =>
                         CanEnterMiseryMire(have)
                         && DungeonHasBigKey[(int)Region.MiseryMire]
-                        && (CanLightTorches(have)
-                            || (!LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.BigKey)
-                                && !LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.BigKey))),
+                        && ((!LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.BigKey)
+                                && !LocationHasItem("[dungeon-D6-B1] Misery Mire - big key", InventoryItemType.BigKey))
+                            || (CanLightTorches(have)
+                                && MiseryMireAccessibleKeyCount())),
                 },
                 new Location
                 {
@@ -1001,9 +998,7 @@ namespace AlttpRandomizer.Rom
                     CanAccess =
                         have =>
                         CanEnterMiseryMire(have)
-                        && CanLightTorches(have)
-                        && (!LocationHasItem("[dungeon-D6-B1] Misery Mire - big chest", InventoryItemType.Key)
-                            || LocationHasItem("[dungeon-D6-B1] Misery Mire - compass", InventoryItemType.Key)),
+                        && CanLightTorches(have),
                 },
 
                 new Location

--- a/AlttpRandomizer/Rom/RomLocationsCasual.cs
+++ b/AlttpRandomizer/Rom/RomLocationsCasual.cs
@@ -2762,7 +2762,7 @@ namespace AlttpRandomizer.Rom
 
         protected override bool CanDefeatSkullWoods(List<InventoryItemType> have)
         {
-            return CanEnterSkullWoods2(have);
+            return CanEnterSkullWoods2(have)
                 && !(LocationHasItem("[dungeon-D3-B1] Skull Woods - big chest", InventoryItemType.FireRod)
                     && LocationHasItem("[dungeon-D3-B1] Skull Woods - Entrance to part 2", InventoryItemType.BigKey));
         }


### PR DESCRIPTION
Previously I had created several "quick fix" logic updates to a few locations to correct a few errors.  This latest update reverts several of those in favor of a better methodology.

I created a Boolean array that is updated whenever a big key has been added to a dungeon, where each value in the array is associated with each region.  Then I updated every dungeon's Big Chest logic to check that the Big Key has been placed before the big chest can be accessed.  I also added this to a few logic points where the game is checking for the big key in certain chests (without doing so it could check an empty chest that could be later filled with the big key and not be checked again). (See issues #266 and #267 ). 

Note: The size of this array is based on the number of regions.  So if, for some reason, additional regions are added in the future this will be sized accordingly, and it can be used immediately following by just referencing it where needed.

I also added a function called MiseryMireAccessibleKeyCount which checks that two (or more) keys are accessible outside of the areas through the southwest locked door in the big hub room.  Then I updated the Misery Mire big chest logic to check these keys if the big key is in either the Compass or Big Key chests.  This will help ensure that an already-rare key lock can't happen (see issue #296 )

I also added a Message Box that will appear when you use the Bulk Create option.  Many times I've started a bulk creation and switched away only to keep coming back to check if it's complete.

Other logic fixes (lamp in the eye bridge or at Trinexx in Turtle Rock) Super Bomb logic updates, file+folder path fixes, etc... still remain in tact.

[Edit: I also added logic to change Cs to Gs in the seed number if a different difficulty is selected.   Also entering a seed that starts with C or G also correctly selects the appropriate difficulty in the drop down to ensure consistency. See issue #275 )]