### PR TITLE
Performance Optimizing

### DIFF
--- a/AlttpRandomizer/Random/Randomizer.cs
+++ b/AlttpRandomizer/Random/Randomizer.cs
@@ -368,16 +368,19 @@ namespace AlttpRandomizer.Random
                 // Generate candidate item list
                 foreach (var candidateItem in insertedItemPool)
                 {
-                    haveItems.Add(candidateItem);
-
-                    var newLocations = region == Region.Progression ? romLocations.GetAvailableLocations(haveItems) : romLocations.GetAvailableLocations(haveItems, region);
-
-                    if (newLocations.Count > currentLocations.Count)
+                    if (!Item.ommitAccessibleCheck(candidateItem)) // Can ommit the following logic for most items, as it doesn't do any thing
                     {
-                        romLocations.TryInsertCandidateItem(currentLocations, candidateItemList, candidateItem);
-                    }
+                        haveItems.Add(candidateItem);
 
-                    haveItems.Remove(candidateItem);
+                        var newLocations = region == Region.Progression ? romLocations.GetAvailableLocations(haveItems) : romLocations.GetAvailableLocations(haveItems, region);
+
+                        if (newLocations.Count > currentLocations.Count)
+                        {
+                            romLocations.TryInsertCandidateItem(currentLocations, candidateItemList, candidateItem);
+                        }
+
+                        haveItems.Remove(candidateItem);
+                    }
                 }
 
                 AdjustCandidateItems(candidateItemList, haveItems, romLocations);

--- a/AlttpRandomizer/Rom/Item.cs
+++ b/AlttpRandomizer/Rom/Item.cs
@@ -259,6 +259,57 @@ namespace AlttpRandomizer.Rom
             return new[] { retVal };
         }
 
+        public static bool ommitAccessibleCheck(InventoryItemType item)
+        {
+            bool retval;
+
+            switch (item)
+            {
+                case InventoryItemType.Nothing:
+                case InventoryItemType.BlueShield:
+                case InventoryItemType.RedShield:
+                case InventoryItemType.MirrorShield:
+                case InventoryItemType.Boomerang:
+                case InventoryItemType.PieceOfHeart:
+                case InventoryItemType.StaffOfByrna:
+                case InventoryItemType.BugCatchingNet:
+                case InventoryItemType.BlueMail:
+                case InventoryItemType.RedMail:
+                case InventoryItemType.Compass:
+                case InventoryItemType.HeartContainerNoAnimation:
+                case InventoryItemType.Bomb:
+                case InventoryItemType.ThreeBombs:
+                case InventoryItemType.RedBoomerang:
+                case InventoryItemType.TenBombs:
+                case InventoryItemType.Map:
+                case InventoryItemType.OneRupee:
+                case InventoryItemType.FiveRupees:
+                case InventoryItemType.TwentyRupees:
+                case InventoryItemType.HeartContainerNoRefill:
+                case InventoryItemType.HeartContainer:
+                case InventoryItemType.OneHundredRupees:
+                case InventoryItemType.FiftyRupees:
+                case InventoryItemType.Heart:
+                case InventoryItemType.Arrow:
+                case InventoryItemType.TenArrows:
+                case InventoryItemType.SmallMagic:
+                case InventoryItemType.ThreeHundredRupees:
+                case InventoryItemType.TwentyRupees2:
+                case InventoryItemType.FiftyBombCap:
+                case InventoryItemType.SeventyArrowCap:
+                case InventoryItemType.HalfMagic:
+                case InventoryItemType.QuarterMagic:
+                    retval = true;
+                    break;
+                default:
+                    // Anything not listed here is a 1
+                    retval = false;
+                    break;
+            }
+
+            return retval;
+        }
+
         public static byte[] GetCheckLocation(InventoryItemType item)
         {
             byte retVal;


### PR DESCRIPTION
There are a bunch of checks if the number of accessible locations has increased that are unnecessary as most of the item don't influence the accessibility of the locations.
I have put a function into the item.cs - file that chooses for which items the check can be ommitted and checked it in the randomizer.cs.
This decreased the time to generate a seed to <1 sec...

Perhaps someone would like to doublecheck the item list, so there is no item in there that is checked in glitched difficulty etc.